### PR TITLE
Add resume to the header for KMSTestCase.h

### DIFF
--- a/KMSTestCase.h
+++ b/KMSTestCase.h
@@ -105,4 +105,12 @@
 
 - (void)pause;
 
+/**
+ Calls <resume> on the server after a call to <runUntilPaused>/<pause>.
+
+ After this call, it's ok to call <runUntilPaused>/<pause> again to perform more work.
+ */
+
+- (void)resume;
+
 @end

--- a/KMSTestCase.m
+++ b/KMSTestCase.m
@@ -67,23 +67,6 @@
     return url;
 }
 
-
-- (void)runUntilPaused
-{
-    [self.server runUntilPaused];
-}
-
-- (void)pause
-{
-    [self.server pause];
-}
-
-- (void)resume
-{
-    [self.server resume];
-}
-
-
 - (NSString*)stringForRequest:(NSURLRequest*)request
 {
     __block NSString* string = nil;
@@ -106,5 +89,22 @@
 
     return [string autorelease];
 }
+
+- (void)runUntilPaused
+{
+    [self.server runUntilPaused];
+}
+
+- (void)pause
+{
+    [self.server pause];
+}
+
+- (void)resume
+{
+    [self.server resume];
+}
+
+
 
 @end


### PR DESCRIPTION
It's a public method and this gets rid of an Xcode warning.

Also - move the implementation methods to the same order as their
declaration in the header file.

If you could also apply this changes to the ConnectionKit repository - it will get rid of an error in the tests.
