### PR TITLE
Set the state to Running each time that runUntilPause is called.

### DIFF
--- a/KMSServer.m
+++ b/KMSServer.m
@@ -180,6 +180,7 @@ NSString *const OutputRunMode = @"OutputRunMode"; //NSDefaultRunLoopMode
     KMSAssert(self.state != KMSStopped);
 
     KMSLogDetail(@"running until paused");
+	self.state = KMSRunning;
     while (self.state != KMSPauseRequested)
     {
         @autoreleasepool {


### PR DESCRIPTION
I use the server in a way where I create it once per suite and then call it multiple times in that suite and found that the runUntilPause would always have the state set to pause after the first time, so I added this line to ensure that the state was running.
